### PR TITLE
Put worktree outside of repo in manual steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -154,7 +154,7 @@ const getFailedBackportCommentBody = ({
   errorMessage: string;
   head: string;
 }) => {
-  const worktreePath = `.worktrees/backport-${base}`;
+  const worktreePath = `../.worktrees/backport-${base}`;
   return [
     `The backport to \`${base}\` failed:`,
     "```",
@@ -167,7 +167,7 @@ const getFailedBackportCommentBody = ({
     "# Create a new working tree",
     `git worktree add ${worktreePath} ${base}`,
     "# Navigate to the new working tree",
-    `cd ${worktreePath}`,
+    `pushd ${worktreePath}`,
     "# Create a new branch",
     `git switch --create ${head}`,
     "# Cherry-pick the merged commit of this pull request and resolve the conflicts",
@@ -175,7 +175,7 @@ const getFailedBackportCommentBody = ({
     "# Push it to GitHub",
     `git push --set-upstream origin ${head}`,
     "# Go back to the original working tree",
-    "cd ../..",
+    "popd",
     "# Delete the working tree",
     `git worktree remove ${worktreePath}`,
     "```",


### PR DESCRIPTION
If a backport fails then steps are given to create a backport manually. Currently, these steps put the worktree inside the repository folder, which causes git to see the worktree as untracked files. This change puts the worktree outside of the repository to avoid this problem.

Signed-off-by: Andrew Ross <andrross@amazon.com>
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
