### PR TITLE
Retry post error for filtering out files

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -105,7 +105,14 @@ const backportOnce = async ({
   await git("switch", base);
   await git("switch", "--create", head);
   try {
-    await git("cherry-pick", "-x", "-n", commitSha);
+    try {
+      await git("cherry-pick", "-x", "-n", commitSha);
+    } catch (error: unknown) {
+      logError(
+        "Possibly a conflict error. Trying to skip possible conflict files. ",
+      );
+    }
+
     for (const file of filesToSkip) {
       await git("checkout", "HEAD", file);
     }


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- Adds a retry mechanism in case of merge conflicts for skipping files
 
### Issues Resolved
- None
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
