### PR TITLE
Add repo name to worktree path

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -155,13 +155,15 @@ const getFailedBackportCommentBody = ({
   commitSha,
   errorMessage,
   head,
+  repo,
 }: {
   base: string;
   commitSha: string;
   errorMessage: string;
   head: string;
+  repo: string;
 }) => {
-  const worktreePath = `../.worktrees/backport-${base}`;
+  const worktreePath = `../.worktrees/${repo}/backport-${base}`;
   return [
     `The backport to \`${base}\` failed:`,
     "```",
@@ -169,6 +171,8 @@ const getFailedBackportCommentBody = ({
     "```",
     "To backport manually, run these commands in your terminal:",
     "```bash",
+    "# Navigate to the root of your repository",
+    "cd $(git rev-parse --show-toplevel)",
     "# Fetch latest updates from GitHub",
     "git fetch",
     "# Create a new working tree",
@@ -327,6 +331,7 @@ const backport = async ({
               commitSha: mergeCommitSha,
               errorMessage: error.message,
               head,
+              repo
             }),
             issue_number: number,
             owner,


### PR DESCRIPTION
This addresses two issues: 1) no longer assume that the user is working from the root directory of the repository, and 2) put the repo name in the working tree path to avoid any potential conflicts from backports from other repositories.

Signed-off-by: Andrew Ross <andrross@amazon.com>

This addresses [@rursprung's comment](https://github.com/VachaShah/backport/pull/5#issuecomment-1296125746)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
