### PR TITLE
Add comment support for file_to_skip for visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.0 (4/10/2024)
+
+- Add comment support for file_to_skip for visibility ([#13](https://github.com/VachaShah/backport/pull/13))
+
 # 2.1.0 (10/28/2022)
 
 - Put worktree outside of repo in manual steps ([#5](https://github.com/VachaShah/backport/pull/5))


### PR DESCRIPTION
### Description
- Add comment support for file_to_skip for visibility
- The new PR will have details as a comment if files were skipped for the PR to succeed
 
### Issues Resolved
- N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
